### PR TITLE
Add ability to conditionally retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+
+  * Added ability to specify a conditional retry, useful for only reattempting when its safe to do so.
+    * By default retries will always be attempted.
+  * Moved to keyword arguments for initialisation to support future features, this is a breaking change.
+  * Organised default arguments for future expansion.
+
 1.0.0
 
   * Initial release to support need for backoff in [Bellroy](https://bellroy.com/) projects.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 ## Usage
 
-Without any arguments given to the constructor a basic exponential backoff interval (2, 4, 8, 16 to be precise) is used with `sleep` being used to wait, as a nicety this is available as `.attempt`:
+Without any arguments given to the constructor a basic backoff interval (2, 4, 8, 16 to be precise) is used with `sleep` being used to wait, as a nicety this is available as `.attempt`:
 
 ```ruby
 # Shortcut for: ThereWasAnAttempt.new.attempt

--- a/spec/lib/there_was_an_attempt_spec.rb
+++ b/spec/lib/there_was_an_attempt_spec.rb
@@ -5,11 +5,12 @@ require 'logger'
 require 'dry/monads/result'
 
 describe ThereWasAnAttempt do
-  let(:service) { described_class.new(intervals, wait) }
+  let(:service) { described_class.new(intervals: intervals, wait: wait, reattempt: reattempt) }
 
   let(:intervals) { [0.1, 0.2] }
   let(:sensor) { instance_double(Logger) }
   let(:wait) { ->(seconds) { sensor.info(seconds) } }
+  let(:reattempt) { ->(failure) { true } }
 
   describe '#attempt' do
     context 'when the block never succeeds' do
@@ -46,6 +47,14 @@ describe ThereWasAnAttempt do
         expect(sensor).to receive(:info).with(0.1)
         expect(sensor).not_to receive(:info).with(0.2)
         expect(result).to eq(Dry::Monads::Success(true))
+      end
+
+      context 'when reattempt method returns false' do
+        let(:reattempt) { ->(failure) { false } }
+
+        specify do
+          expect(result).to eq(Dry::Monads::Failure(false))
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds the ability to specify a function to evaluate whether to continuing retrying, this may be useful for helping ensure you only retry when it's safe to do so, e.g. on a selection of safe HTTP response codes / methods.

The PR also rejigs the initialiser to move it to keyword arguments helping make room for additional functionality in the future, this is a breaking change.